### PR TITLE
IO accounting implementation through netlink

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -1,3 +1,3 @@
-SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios
+SUBDIRS  = zfs zpool zdb zhack zinject zstreamdump ztest zpios zfs_iostat
 SUBDIRS += mount_zfs fsck_zfs zvol_id vdev_id arcstat dbufstat zed
 SUBDIRS += arc_summary

--- a/cmd/zfs_iostat/Makefile.am
+++ b/cmd/zfs_iostat/Makefile.am
@@ -1,0 +1,15 @@
+include $(top_srcdir)/config/Rules.am
+
+DEFAULT_INCLUDES += \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/lib/libspl/include
+
+sbin_PROGRAMS = zfs_iostat
+
+zfs_iostat_SOURCES = \
+	zfs_iostat.c
+
+zfs_iostat_LDADD = \
+	$(top_builddir)/lib/libioacct/libioacct.la
+
+zfs_iostat_LDFLAGS = -pthread

--- a/cmd/zfs_iostat/zfs_iostat.c
+++ b/cmd/zfs_iostat/zfs_iostat.c
@@ -1,0 +1,142 @@
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <linux/netlink.h>
+#include <linux/socket.h>
+#include <sys/epoll.h>
+
+#include "libioacct.h"
+
+int
+open_netlink(void)
+{
+	int netlink_socket;
+	int netlink_group = ZFS_NL_IO_GRP;
+	struct sockaddr_nl netlink_addr;
+
+	memset(&netlink_addr, 0, sizeof (netlink_addr));
+	netlink_addr.nl_family = AF_NETLINK;
+	netlink_addr.nl_groups = ZFS_NL_IO_GRP;
+	netlink_socket = socket(AF_NETLINK, SOCK_RAW, ZFS_NL_IO_PROTO);
+
+	if (bind(netlink_socket, (struct sockaddr *) &netlink_addr,
+		sizeof (netlink_addr)) < 0) {
+		printf("bind() unsuccessfull: %s.\n", strerror(errno));
+		return (-1);
+	}
+
+	/*
+	 * Use '270' vs. SOL_NETLINK below, due to strange error
+	 * linux/socket.h:318:
+	 * #define SOL_NETLINK	270
+	 * When use this macro compile fails:
+	 * 'zfs_iostat.c:35:19: error: 'SOL_NETLINK' undeclared'
+	 */
+	if (setsockopt(
+		netlink_socket, 270, NETLINK_ADD_MEMBERSHIP,
+		&netlink_group, sizeof (netlink_group)) < 0) {
+		printf("setsockopt() unsuccessfull: %s.\n", strerror(errno));
+		return (-1);
+	}
+
+	return (netlink_socket);
+}
+
+void
+read_event(int sock)
+{
+	struct iovec iov;
+	struct msghdr msgbuf;
+	struct nlmsghdr *nl_header;
+	nl_msg *io_msg;
+	zfs_io_info_t zii;
+	char zfs_op[3];
+
+	io_msg = malloc(NETLINK_MSGLEN);
+	if (!io_msg) {
+		printf("malloc() unsuccessfull: %s\n.", strerror(errno));
+		return;
+	}
+	nl_header = (struct nlmsghdr *)malloc(NLMSG_SPACE(NETLINK_MSGLEN));
+	if (!nl_header) {
+		printf("malloc() unsuccessfull: %s\n.", strerror(errno));
+		return;
+	}
+
+	memset(nl_header, 0, NLMSG_SPACE(NETLINK_MSGLEN));
+	nl_header->nlmsg_len = NLMSG_SPACE(NETLINK_MSGLEN);
+
+	iov.iov_base = (void *)nl_header;
+	iov.iov_len = NLMSG_SPACE(NETLINK_MSGLEN);
+	msgbuf.msg_name = NULL;
+	msgbuf.msg_namelen = 0;
+	msgbuf.msg_iov = &iov;
+	msgbuf.msg_iovlen = 1;
+	msgbuf.msg_control = NULL;
+	msgbuf.msg_controllen = 0;
+	msgbuf.msg_flags = 0;
+
+	if (recvmsg(sock, &msgbuf, 0) <= 0) {
+		printf("recvmsg() unsuccessfull: %s\n.", strerror(errno));
+		return;
+	}
+
+	memcpy(io_msg, NLMSG_DATA(nl_header), NETLINK_MSGLEN);
+	deserialize_io_info(&zii, io_msg);
+	free(io_msg);
+	free(nl_header);
+
+	switch (zii.op) {
+		case ZFS_NL_READ:
+			strncpy(zfs_op, "cr\0", 3);
+			break;
+		case ZFS_NL_WRITE:
+			strncpy(zfs_op, "cw\0", 3);
+			break;
+		case ZFS_NL_READPAGE:
+			strncpy(zfs_op, "mr\0", 3);
+			break;
+		case ZFS_NL_WRITEPAGE:
+			strncpy(zfs_op, "mw\0", 3);
+			break;
+		default:
+			strcpy(zfs_op, "--");
+	}
+	printf("%s %d %zd %s\n", zii.fsname, zii.pid, zii.nbytes, zfs_op);
+}
+
+int
+main(int argc, char *argv[])
+{
+	int epoll_fd, netlink_socket, nr_events;
+	struct epoll_event event = {
+		.events = 0
+	};
+
+	netlink_socket = open_netlink();
+	if (netlink_socket < 0)
+		return (netlink_socket);
+
+	epoll_fd = epoll_create1(0);
+	if (epoll_fd == -1) {
+		printf("epoll_create() unsuccessfull: %s.\n", strerror(errno));
+		return (-1);
+	}
+
+	event.data.fd = netlink_socket;
+	event.events = EPOLLIN;
+	if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, netlink_socket, &event) == -1) {
+		printf("epoll_ctl() unsuccessfull: %s.\n", strerror(errno));
+		return (-1);
+	}
+
+	while (1) {
+		nr_events = epoll_wait(epoll_fd, &event, 1, -1);
+		read_event(event.data.fd);
+	}
+
+	return (0);
+}

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,7 @@ AC_CONFIG_FILES([
 	lib/libspl/include/util/Makefile
 	lib/libavl/Makefile
 	lib/libefi/Makefile
+	lib/libioacct/Makefile
 	lib/libnvpair/Makefile
 	lib/libunicode/Makefile
 	lib/libuutil/Makefile
@@ -111,6 +112,7 @@ AC_CONFIG_FILES([
 	cmd/dbufstat/Makefile
 	cmd/arc_summary/Makefile
 	cmd/zed/Makefile
+	cmd/zfs_iostat/Makefile
 	contrib/Makefile
 	contrib/bash_completion.d/Makefile
 	contrib/dracut/Makefile

--- a/include/libioacct.h
+++ b/include/libioacct.h
@@ -1,0 +1,42 @@
+#ifndef	_LIBIOACCT_H
+#define	_LIBIOACCT_H
+
+#ifdef _KERNEL
+#include <net/sock.h>
+#include <linux/netlink.h>
+#include <linux/kernel.h>
+#include <linux/kthread.h>
+#include <linux/sysctl.h>
+#include "sys/zfs_znode.h"
+#endif
+
+#ifndef _KERNEL
+#include "libzfs.h"
+#include <string.h>
+#endif
+
+#define	ZFS_NL_IO_PROTO	NETLINK_USERSOCK
+#define	ZFS_NL_IO_GRP	21
+
+typedef char nl_msg;
+
+typedef enum {
+	ZFS_NL_READ,
+	ZFS_NL_WRITE,
+	ZFS_NL_READPAGE,
+	ZFS_NL_WRITEPAGE
+} zfs_io_type_t;
+
+typedef struct zfs_io_info {
+	pid_t pid;
+	ssize_t nbytes;
+	zfs_io_type_t op;
+	char fsname[ZFS_MAXNAMELEN];
+} zfs_io_info_t;
+
+#define	NETLINK_MSGLEN sizeof (pid_t) + sizeof (ssize_t) \
+	+ sizeof (zfs_io_type_t) + ZFS_MAXNAMELEN
+
+void deserialize_io_info(zfs_io_info_t *zii, nl_msg *io_msg);
+
+#endif // _LIBIOACCT_H

--- a/include/sys/zfs_ioctl.h
+++ b/include/sys/zfs_ioctl.h
@@ -422,6 +422,7 @@ typedef struct zfsdev_state {
 	void			*zs_zevent;	/* zevent data */
 } zfsdev_state_t;
 
+extern boolean_t zfs_nl_ioacct_enabled(void);
 extern void *zfsdev_get_state(minor_t minor, enum zfsdev_state_type which);
 extern int zfsdev_getminor(struct file *filp, minor_t *minorp);
 extern minor_t zfsdev_minor_alloc(void);

--- a/include/sys/zfs_nl_ioacct.h
+++ b/include/sys/zfs_nl_ioacct.h
@@ -1,0 +1,16 @@
+#ifndef	_SYS_ZFS_NL_IOACCT_H
+#define	_SYS_ZFS_NL_IOACCT_H
+
+#include <linux/netlink.h>
+#include <linux/kernel.h>
+#include <linux/kthread.h>
+#include <linux/sysctl.h>
+#include "sys/zfs_znode.h"
+#include "libioacct.h"
+
+int zfs_nl_ioacct_init(void);
+void zfs_nl_ioacct_fini(void);
+void zfs_nl_ioacct_send(zfs_io_info_t *zii);
+void serialize_io_info(const zfs_io_info_t *zii, nl_msg *io_msg);
+
+#endif // _SYS_ZFS_NL_IOACCT_H

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -5,3 +5,6 @@ SUBDIRS = libspl libavl libefi libshare libunicode
 # These four libraries, which are installed as the final build product,
 # incorporate the five convenience libraries given above.
 SUBDIRS += libuutil libnvpair libzpool libzfs_core libzfs
+
+# Netlink io accounting
+SUBDIRS += libioacct

--- a/lib/libioacct/Makefile.am
+++ b/lib/libioacct/Makefile.am
@@ -1,0 +1,16 @@
+include $(top_srcdir)/config/Rules.am
+
+DEFAULT_INCLUDES += \
+	-I$(top_srcdir)/include \
+	-I$(top_srcdir)/lib/libspl/include
+
+lib_LTLIBRARIES = libioacct.la
+
+USER_C = \
+	libioacct.c
+
+KERNEL_C =
+
+nodist_libioacct_la_SOURCES = \
+	$(USER_C) \
+	$(KERNEL_C)

--- a/lib/libioacct/libioacct.c
+++ b/lib/libioacct/libioacct.c
@@ -1,0 +1,15 @@
+#include "libioacct.h"
+
+void
+deserialize_io_info(zfs_io_info_t *zii, nl_msg *io_msg)
+{
+	nl_msg *seeker = io_msg;
+
+	memcpy(&zii->pid, seeker, sizeof (pid_t));
+	seeker += sizeof (pid_t);
+	memcpy(&zii->nbytes, seeker, sizeof (ssize_t));
+	seeker += sizeof (ssize_t);
+	memcpy(&zii->op, seeker, sizeof (zfs_io_type_t));
+	seeker += sizeof (zfs_io_type_t);
+	memcpy(&zii->fsname, seeker, ZFS_MAXNAMELEN);
+}

--- a/module/zfs/Makefile.in
+++ b/module/zfs/Makefile.in
@@ -84,6 +84,7 @@ $(MODULE)-objs += zfs_fm.o
 $(MODULE)-objs += zfs_fuid.o
 $(MODULE)-objs += zfs_ioctl.o
 $(MODULE)-objs += zfs_log.o
+$(MODULE)-objs += zfs_nl_ioacct.o
 $(MODULE)-objs += zfs_onexit.o
 $(MODULE)-objs += zfs_replay.o
 $(MODULE)-objs += zfs_rlock.o

--- a/module/zfs/zfs_nl_ioacct.c
+++ b/module/zfs/zfs_nl_ioacct.c
@@ -1,0 +1,82 @@
+#include "sys/zfs_nl_ioacct.h"
+
+struct sock *nl_sk = NULL;
+
+void
+serialize_io_info(const zfs_io_info_t *zii, nl_msg *io_msg)
+{
+	nl_msg *seeker = io_msg;
+	memcpy(seeker, &zii->pid, sizeof (pid_t));
+	seeker += sizeof (pid_t);
+	memcpy(seeker, &zii->nbytes, sizeof (ssize_t));
+	seeker += sizeof (ssize_t);
+	memcpy(seeker, &zii->op, sizeof (zfs_io_type_t));
+	seeker += sizeof (zfs_io_type_t);
+	memcpy(seeker, &zii->fsname, ZFS_MAXNAMELEN);
+}
+
+void
+zfs_nl_ioacct_send(zfs_io_info_t *zii)
+{
+	size_t nl_msglen;
+	struct nlmsghdr *nl_header;
+	struct sk_buff *skb;
+	nl_msg *io_msg;
+
+	nl_msglen = NETLINK_MSGLEN;
+
+	io_msg = kmalloc(nl_msglen, GFP_KERNEL);
+	if (!io_msg)
+		goto out;
+
+	serialize_io_info(zii, io_msg);
+
+	skb = nlmsg_new(nl_msglen, GFP_KERNEL);
+	if (!skb)
+		goto out;
+
+	nl_header = nlmsg_put(skb, 0, 0, NLMSG_DONE, nl_msglen, 0);
+	if (!nl_header)
+		goto out;
+
+	memcpy(nlmsg_data(nl_header), io_msg, nl_msglen);
+	nlmsg_multicast(nl_sk, skb, 0, ZFS_NL_IO_GRP, 0);
+
+out:
+	kfree(io_msg);
+}
+
+static int
+zfs_nl_ioacct_netlink_init(void)
+{
+	nl_sk = netlink_kernel_create(&init_net, ZFS_NL_IO_PROTO, NULL);
+	if (!nl_sk)
+		return (-1);
+
+	return (0);
+}
+
+int
+zfs_nl_ioacct_init(void)
+{
+	int netlink_id;
+
+	printk(KERN_INFO "ZFS: netlink ioacct: initializing\n");
+
+	netlink_id = zfs_nl_ioacct_netlink_init();
+	if (netlink_id < 0) {
+		printk(KERN_ERR
+			"ZFS: netlink ioacct: error creating socket.\n");
+		return (netlink_id);
+	}
+
+	printk(KERN_INFO "ZFS: netlink ioacct: initialized\n");
+
+	return (0);
+}
+
+void
+zfs_nl_ioacct_fini(void)
+{
+	netlink_kernel_release(nl_sk);
+}


### PR DESCRIPTION
This patchset introduces per filesystem zfs io accounting.
This feature is required in my test and production environments for monitoring io per filesystem.

Some details:
- accounting implementation based on sending netlink multicast messages from zfs kernel module (and may by received in userspace);
- **on each io operation zfs kernel module sends netlink multicast message, which contains full information about it: filesystem, pid, bytes, operation (read, write, mapped read, mapped write);**
- **sending netlink messages from kernel fully non-blocking;**
- accounting implemented on zpl/zfs-layers;
- accounting managed by kernel mode parameter:

```
/sys/module/zfs/parameters/zfs_nl_ioacct # 0 - disable, any other - enable
```
- this PR consists of two commits:
  - one for kernel module;
  - one for simple userspace utility, zfs_iostat (see below);
- **zfs_iostat** utulity allow to get io statistics in realtime to stdout using next format:
  
  ```
  <filesystem> <pid> <bytes> <operation_type>
  ```
  
  Where _operation_type may_ be:
  
  ```
  cr - common read
  cw - common write
  mr - mapped read
  mw - mapped write
  ```
  
   Example output:
  
  ```
  $ sudo ./cmd/zfs_iostat/zfs_iostat
  zroot/instances/fs-one 31333 4096 cr
  zroot/instances/fs-one 31333 4096 cr
  ```
